### PR TITLE
Set the island.overridelimit setting to true when converting.

### DIFF
--- a/UABlockConverter/src/com/wasteofplastic/uablockconverter/UABlockConverter.java
+++ b/UABlockConverter/src/com/wasteofplastic/uablockconverter/UABlockConverter.java
@@ -166,6 +166,7 @@ public class UABlockConverter extends JavaPlugin implements Listener {
 	// distance
 	ASkyBlockConf.set("island.distance", uSkyBlockConf.getInt("options.island.distance",110));
 	ASkyBlockConf.set("island.protectionRange", uSkyBlockConf.getInt("options.island.protectionRange",105));
+	ASkyBlockConf.set("island.overridelimit", true); //Set to true as otherwise values that would be valid in uSkyBlock become invalid.
 	// Height
 	int height = uSkyBlockConf.getInt("options.island.height",150);
 	ASkyBlockConf.set("general.islandlevel", height);


### PR DESCRIPTION
If this isn't done, the default values become invalid, as the default
protection is smaller than the one that ASkyBlock expects.  Thus, the message `Island protection range must be 96 or less, (island range -16)` is shown.  It doesn't make sense to convert automatically `island.overridelimit` would need to still be manually set for these values to work, so I'm setting that value to true.  (uSkyBlock's config doesn't have a limit like this, so there is no value to get from the configuration)
